### PR TITLE
BugFix: tag fetches now in order

### DIFF
--- a/src/components/tags/CreateTagForm.js
+++ b/src/components/tags/CreateTagForm.js
@@ -87,8 +87,10 @@ export const NewTagForm = ({ getTags }) => {
 
                         <button onClick={(e) => {
                             submitTag(e)
-                            updateForm({label: ""})
-                            history.push("/tags")
+                            .then(() => {
+                                updateForm({label: ""})
+                                history.push("/tags")
+                            })
                         }} className="submit-button">
                             Submit
                         </button>


### PR DESCRIPTION
# Description

tag fix

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Issue: when creating a new tag, sometimes list of tags would not update with the added tag. Added .then() chain to ensure fetches are made in correct order.

- [ ] Navigate to creating tag page
- [ ] Make a new tag
- [ ] repeat several times, fetches should always occur in POST, GET order

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings