### PR TITLE
Feat: buttonControls added to all posts view

### DIFF
--- a/src/components/posts/AllPosts.js
+++ b/src/components/posts/AllPosts.js
@@ -9,6 +9,7 @@ import { Settings } from "../utils/Settings";
 import { getSingleUser } from "../users/UserManager";
 import { useHistory } from "react-router-dom";
 import useAdminCheck from "../utils/useAdminCheck";
+import { ButtonControls } from "../buttonControls/ButtonControls";
 
 
 export const AllPosts = () => {
@@ -211,26 +212,7 @@ export const AllPosts = () => {
                     return <div key={post.id} className="posts">
                         {
                             currentUser === post.rareUser.user?.id || adminCheck2 ?
-                                <button className="btn-deleteIfUser"
-                                    onClick={
-                                        () => {
-                                            if (confirm("Are you sure you want to delete this?") == true) {
-                                                deletePost(post.id)
-                                                    .then(
-                                                        () => {
-                                                            setToggle(!toggle)
-                                                        }
-                                                    )
-                                            } else {
-                                                () => {
-                                                    history.push(`/posts/single/${post.id}`)
-                                                }
-                                            }
-                                        }
-                                    }
-                                >
-                                    <img className="deleteIcon" src={`${Settings.DeleteIcon}`} width="25px" height="25px" />
-                                </button>
+                                <ButtonControls itemType={"post"} postId={post.id} id={post.id} />
                                 :
                                 ""
                         }


### PR DESCRIPTION
# Description

All posts now has edit and delete buttons from buttonControls.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Navigate to /posts/all
- [ ] Clicking the edit button next to a post should take user to the edit page for that post
- [ ] Clicking the delete button next to a post should delete the post and take user to homepage
- [ ] buttons should only appear for posts by the current user or admin

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings