### PR TITLE
Feat: creating reactions added

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -14,6 +14,8 @@ import { SinglePost } from "./posts/SinglePost.js"
 import { NewTagForm } from "./tags/CreateTagForm.js"
 import { NewCategoryForm } from "./categories/CreateCategoryForm.js"
 import { CommentForm } from "./comments/CommentForm.js"
+import { NewReactionForm } from "./reactions/CreateReactionForm.js"
+import { ReactionList } from "./reactions/ReactionsList.js"
 
 export const ApplicationViews = () => {
   return (
@@ -33,11 +35,17 @@ export const ApplicationViews = () => {
       <Route exact path="/tags">
         <AllTags />
       </Route>
+      <Route exact path="/reactions">
+        <ReactionList />
+      </Route>
       <Route exact path="/tags/edit/:tagId(\d+)">
         <EditTagForm />
       </Route>
       <Route exact path="/tags/new">
         <NewTagForm />
+      </Route>
+      <Route exact path="/reactions/new">
+        <NewReactionForm />
       </Route>
       <Route exact path="/newPost">
         <CreatePosts editing={false} />

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -51,6 +51,9 @@ export const NavBar = ({ token, setToken }) => {
                 <div className="navbar-item">
                   <Link to="/newPost" className="navbar-item">New Post</Link>
                 </div>
+                <div className="navbar-item">
+                  <Link to="/reactions" className="navbar-item">Reaction List</Link>
+                </div>
                 {/* add link to UserList view */}
               </>
               : ""

--- a/src/components/reactions/CreateReactionForm.js
+++ b/src/components/reactions/CreateReactionForm.js
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from "react";
+import { useHistory } from "react-router-dom";
+import { createReaction } from "./ReactionManager";
+
+// define a function that returns the create new reaction form
+export const NewReactionForm = ({ getReactions }) => {
+
+    const [form, updateForm] = useState({ label: "", imageUrl: "" })
+    const history = useHistory()
+
+    const submitReaction = (e) => {
+        e.preventDefault()
+        const newReaction = {
+            label: form.label,
+            imageUrl: form.imageUrl
+        }
+        return createReaction(newReaction)
+    }
+
+    return (
+        <>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="reaction">Reaction Name</label>
+                    <input
+                        required autoFocus
+                        type="text" id="reaction"
+                        className="form-control"
+                        placeholder="add text"
+                        value={form.label}
+                        onChange={
+                            (e) => {
+                                const copy = { ...form }
+                                copy.label = e.target.value
+                                updateForm(copy)
+                            }
+                        }
+                    />
+                    <label htmlFor="reactionUrl">Reaction Image URL</label>
+                    <input
+                        required autoFocus
+                        type="text" id="reactionUrl"
+                        className="form-control"
+                        placeholder="add text"
+                        value={form.imageUrl}
+                        onChange={
+                            (e) => {
+                                const copy = { ...form }
+                                copy.imageUrl = e.target.value
+                                updateForm(copy)
+                            }
+                        }
+                    />
+                    <div className="submitButtonCreateNewReactionForm">
+
+                        <button onClick={(e) => {
+                            submitReaction(e)
+                                .then(() => {
+                                    updateForm({ label: "", imageUrl: "" })
+                                    history.push("/reactions")
+                                })
+                        }} className="submit-button">
+                            Submit
+                        </button>
+                    </div>
+                </div>
+            </fieldset>
+        </>
+    )
+}

--- a/src/components/reactions/CreateReactionForm.js
+++ b/src/components/reactions/CreateReactionForm.js
@@ -15,6 +15,9 @@ export const NewReactionForm = ({ getReactions }) => {
             imageUrl: form.imageUrl
         }
         return createReaction(newReaction)
+                .then(() => {
+                    history.push("/reactions")
+                })
     }
 
     return (

--- a/src/components/reactions/ReactionManager.js
+++ b/src/components/reactions/ReactionManager.js
@@ -1,0 +1,9 @@
+// fetch all the reactions
+import { fetchIt } from "../utils/Fetch"
+import { Settings } from "../utils/Settings"
+
+export const getAllReactions = () => fetchIt(`${Settings.API}/reactions`)
+
+export const createReaction = (reaction) => {
+    return fetchIt(`${Settings.API}/reactions`, "POST", reaction)
+}

--- a/src/components/reactions/ReactionsList.js
+++ b/src/components/reactions/ReactionsList.js
@@ -1,0 +1,14 @@
+import { useHistory } from "react-router-dom"
+
+export const ReactionList = () => {
+    const history = useHistory()
+
+    return <div>
+        <button onClick={() => {
+            history.push("/reactions/new")
+        }}>Create Reaction</button>
+        <div>
+            Reaction List
+        </div>
+        </div>
+}

--- a/src/components/tags/CreateTagForm.js
+++ b/src/components/tags/CreateTagForm.js
@@ -6,23 +6,8 @@ import { getAllTags } from "./TagManager";
 // define a function that returns the create new tag form
 export const NewTagForm = ({ getTags }) => {
 
-    const [form, updateForm] = useState({label: ""})
+    const [form, updateForm] = useState({ label: "" })
     const history = useHistory()
-
-    // define a new function, submitNewTag its purpose will be submitting the new tag to the server 
-    // accepts one parameter, "e"
-    // e.preventDefault()
-    // defines a new  variable which will be an object for the new tag, "newTag"
-    // the object will have one key value pair:
-    // label: form.tag 
-    // define a new variable, fetchOption, method will be POST, headers will be "Content-Type": "application/json"
-    // convert what we're sending to the server into json body: JSON.stringify(newTag)
-    // invoke addtags from tagManager
-
-    // post the newTag to the tags tablbe in db
-    // return fetch("http://localhost:8000/tags", fetchOption) 
-
-    // example:
 
     const submitTag = (e) => {
         e.preventDefault()
@@ -30,40 +15,9 @@ export const NewTagForm = ({ getTags }) => {
             label: form.label,
         }
         return fetchIt(`${Settings.API}/tags`, "POST", newTag)
-                .then(getTags)
-                
-                // .then(getAllTags())
-                // .then(tagsData => setTags(tagsData))
-        // const fetchOption = {
-        //     method: "POST",
-        //     headers: {
-        //         "Content-Type": "application/json"
-        //     },
-        //     body: JSON.stringify(newTag)
-        // }
-
-        // return fetch("http://localhost:8000/tags", fetchOption)
-        // // .then(window.location.reload())
+            .then(getTags)
     }
 
-
-
-
-    // wrap in div className "form-group"
-    // <label htmlFor="tag" "create a new tag" as text for label
-    // input tag
-    // required autoFocus
-    // type="text" id="tag"
-    // className="form-control"
-    // placeholder="add text"
-    // add an onChange function to update what we will send to the server as the user types
-    // accepts a parameter "e" 
-    //  => function body:
-    // defines a new variable, copy, which is equal to { ...form}
-    // set copy.label equal to e.target.value
-    // change the value of form by using updateForm and passing in copy as an argument
-
-    // example:
     return (
         <>
             <fieldset>
@@ -87,10 +41,10 @@ export const NewTagForm = ({ getTags }) => {
 
                         <button onClick={(e) => {
                             submitTag(e)
-                            .then(() => {
-                                updateForm({label: ""})
-                                history.push("/tags")
-                            })
+                                .then(() => {
+                                    updateForm({ label: "" })
+                                    history.push("/tags")
+                                })
                         }} className="submit-button">
                             Submit
                         </button>
@@ -99,6 +53,4 @@ export const NewTagForm = ({ getTags }) => {
             </fieldset>
         </>
     )
-
-    // add a button, which when clicked will will invoke the submit new tag function from the top of this module
 }


### PR DESCRIPTION
# Description

Reaction list page should have placeholder text and a button to create a reaction.
Create reaction form with label and image url fields. Should create a reaction in the database when it 

Fixes #43  (issue)

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] navigate to /reactions/new
- [ ] Should have two text fields
- [ ] Entering text and clicking submit should send POST to /reactions

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings